### PR TITLE
Fix default dhparam location

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -42,7 +42,7 @@ map $http_upgrade $proxy_connection {
 server_names_hash_bucket_size 128;
 
 # Default dhparam
-ssl_dhparam /etc/nginx/dhparam/dhparam.pem;
+ssl_dhparam /etc/nginx/certs/dhparam.pem;
 
 # Set appropriate X-Forwarded-Ssl header
 map $scheme $proxy_x_forwarded_ssl {


### PR DESCRIPTION
When I was developing locally, I noticed that this file was in `nginx/certs` not `nginx/dhparam`