### PR TITLE
Added nginx.conf (server_tokens off)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ${NGINX_FILES_PATH}/vhost.d:/etc/nginx/vhost.d
       - ${NGINX_FILES_PATH}/html:/usr/share/nginx/html
       - ${NGINX_FILES_PATH}/certs:/etc/nginx/certs:ro
+      - ./nginx.conf:/etc/nginx/conf.d/my_nginx.conf:ro
 
   nginx-gen:
     image: jwilder/docker-gen

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,8 @@
+# Hide server tokens
+server_tokens off;
+
+# Redirect www to non-www
+# server {
+#   server_name "~^www\.(.*)$";
+#   return 301 $scheme://$1$request_uri;
+# }


### PR DESCRIPTION
Turned off the server_tokens, so it won't display the running version of nginx to the public.

Also a little example (in the comments of nginx.conf) how to redirect all www tot non-www.