### PR TITLE
Clarify htpasswd usage

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -107,18 +107,18 @@ docker run -d -e VIRTUAL_HOST=your.domain.com \
 
 > Please note that when running a new container to generate certificates with LetsEncrypt (`-e LETSENCRYPT_HOST=your.domain.com`), it may take a few minutes, depending on multiples circunstances.
 
-## Futher Options
+## Further Options
 
 1. Basic Authentication Support
 
-In order to be able to secure your virtual host with basic authentication, you must create a file named as its equivalent VIRTUAL_HOST variable on directory ${NGINX_FILES_PATH}/htpasswd/$VIRTUAL_HOST.
+In order to be able to secure your virtual host with basic authentication, you must create a htpasswd file within `${NGINX_FILES_PATH}/htpasswd/${VIRTUAL_HOST}` via:
 
-After set up this webproxy, you will do the following:
 ```bash
-sudo sh -c "echo -n 'user_name:' >> ${NGINX_FILES_PATH}/your_domain.com"
-sudo sh -c "openssl passwd -apr1 >> ${NGINX_FILES_PATH}/your_domain.com"
+sudo sh -c "echo -n '[username]' >> ${NGINX_FILES_PATH}/htpasswd/${VIRTUAL_HOST}"
+sudo sh -c "openssl passwd -apr1 >> ${NGINX_FILES_PATH}/htpasswd/${VIRTUAL_HOST}"
 ```
-> Please substitute the `${NGINX_FILES_PATH}` with your path information and your virtual host name as `your_domain.com`.
+
+> Please substitute the `${NGINX_FILES_PATH}` with your path information, `[username]` with your username and `${VIRTUAL_HOST}` with your host's domain. You will be prompted for a password.
 
 2. Using multiple networks
 


### PR DESCRIPTION
Slight tweak to the basic auth section to clarify how the htpasswd file
is created and where it should go.