### PR TITLE
Use docker-compose pull to update local images

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -25,9 +25,7 @@ fi
 curl https://raw.githubusercontent.com/jwilder/nginx-proxy/master/nginx.tmpl > nginx.tmpl
 
 # 5. Update local images
-docker pull nginx
-docker pull jwilder/docker-gen
-docker pull jrcs/letsencrypt-nginx-proxy-companion
+docker-compose pull
 
 # 6. Start proxy
 


### PR DESCRIPTION
You can use [`docker-compose pull`](https://docs.docker.com/compose/reference/pull/) command to update local images instead of upgrading them by name.