### PR TITLE
Add logfiles size configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -54,3 +54,9 @@ NGINX_FILES_PATH=/path/to/your/nginx/data
 #
 #USE_NGINX_CONF_FILES=true
 
+#
+# Maximum containers logfile size
+#
+NGINX_MAX_LOG_SIZE=100m
+NGINX_GEN_MAX_LOG_SIZE=25m
+NGINX_LETSENCRYPT_MAX_LOG_SIZE=25m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       - ${NGINX_FILES_PATH}/html:/usr/share/nginx/html
       - ${NGINX_FILES_PATH}/certs:/etc/nginx/certs:ro
       - ${NGINX_FILES_PATH}/htpasswd:/etc/nginx/htpasswd:ro
+    logging:
+      options:
+        max-size: ${NGINX_MAX_LOG_SIZE:-100m}
 
   nginx-gen:
     image: jwilder/docker-gen
@@ -29,6 +32,9 @@ services:
       - ${NGINX_FILES_PATH}/htpasswd:/etc/nginx/htpasswd:ro
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro
+    logging:
+      options:
+        max-size: ${NGINX_GEN_MAX_LOG_SIZE:-25m}
 
   nginx-letsencrypt:
     image: jrcs/letsencrypt-nginx-proxy-companion
@@ -43,6 +49,9 @@ services:
     environment:
       NGINX_DOCKER_GEN_CONTAINER: ${DOCKER_GEN}
       NGINX_PROXY_CONTAINER: ${NGINX_WEB}
+    logging:
+      options:
+        max-size: ${NGINX_LETSENCRYPT_MAX_LOG_SIZE:-25m}
 
 networks:
   default:


### PR DESCRIPTION
Container logs are kept (at least in my machine) in `/var/lib/docker/containers/{CONTAINER_ID}/{CONTAINER_ID}-json.log`. Logs for `nginx` container are getting pretty huge on my machine (~3GB in one week) as they contain access logs for the HTTP server.

This PR adds a config of maximum size of these logs so they do not take all of free disk space on the machine.

By default: 100MB for nginx and 25MB for nginx-gen and nginx-letsencrypt.

I have also used the [default env replacement notation](https://docs.docker.com/compose/compose-file/#variable-substitution) in `docker-compose.yml` not to make this PR a breaking change. If the new variables are not present in your `.env` file, docker-compose should use the new defaults.

Hope you like it :-) And please, do test it before merge in your environment.