### PR TITLE
Add IPv6 Support for Nginx Proxy

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,6 +17,7 @@ LETS_ENCRYPT=nginx-letsencrypt
 # Your external IP address
 #
 IP=0.0.0.0
+IPv6=::/0
 
 #
 # Default Network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     ports:
       - "${IP:-0.0.0.0}:80:80"
       - "${IP:-0.0.0.0}:443:443"
+      - "${IPv6:-::/0}:80:80"
+      - "${IPv6:-::/0}:443:443"
     volumes:
       - ${NGINX_FILES_PATH:-./data}/conf.d:/etc/nginx/conf.d
       - ${NGINX_FILES_PATH:-./data}/vhost.d:/etc/nginx/vhost.d


### PR DESCRIPTION
`ENABLE_IPV6` makes no difference in my IPv6 connectivity tests using several IPv6 test sites. So I've not added this environment variable. After re-reading Docker's documentation, it sounds like this is for enabling IPv6 between containers.

Prerequisite for IPv6 support:
IPv6 address needs to be enabled and assigned on host. IPv6 record also needs to be created in DNS.

Addendum from original issue: IPv6 container to container networking is not supported. See referenced issue below.