### PR TITLE
Use Cloudflare forwarded IPs

### DIFF
--- a/conf.d/realip.conf
+++ b/conf.d/realip.conf
@@ -1,6 +1,25 @@
 # Please set your docker network below
 # in order to forward the user real 
 # ip address to your app container
-set_real_ip_from  172.18.0.0/32;
-real_ip_header    X-Real-IP;
-real_ip_recursive on;
+set_real_ip_from 103.21.244.0/22;
+set_real_ip_from 103.22.200.0/22;
+set_real_ip_from 103.31.4.0/22;
+set_real_ip_from 104.16.0.0/12;
+set_real_ip_from 108.162.192.0/18;
+set_real_ip_from 131.0.72.0/22;
+set_real_ip_from 141.101.64.0/18;
+set_real_ip_from 162.158.0.0/15;
+set_real_ip_from 172.64.0.0/13;
+set_real_ip_from 173.245.48.0/20;
+set_real_ip_from 188.114.96.0/20;
+set_real_ip_from 190.93.240.0/20;
+set_real_ip_from 197.234.240.0/22;
+set_real_ip_from 198.41.128.0/17;
+set_real_ip_from 2400:cb00::/32;
+set_real_ip_from 2606:4700::/32;
+set_real_ip_from 2803:f800::/32;
+set_real_ip_from 2405:b500::/32;
+set_real_ip_from 2405:8100::/32;
+set_real_ip_from 2c0f:f248::/32;
+set_real_ip_from 2a06:98c0::/29;
+real_ip_header X-Forwarded-For;


### PR DESCRIPTION
@evertramos Here's the PR for forwarding IPs over Cloudflare's proxies. I've added back in the IPv6 addresses as users could be connecting to Cloudflare over IPv6 even if Cloudflare is connecting to the server (Docker host) over IPv4.

I verified both forwarded IPv4 and IPv6 addresses were successfully logged by Apache containers. I can show you my logs if you need further confirmation.

This is referencing issue: https://github.com/evertramos/docker-compose-letsencrypt-nginx-proxy-companion/issues/53