### PR TITLE
IPv6 NAT

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,6 +17,7 @@ LETS_ENCRYPT=nginx-letsencrypt
 # Your external IP address
 #
 IP=0.0.0.0
+IPv6=::1
 
 #
 # Default Network

--- a/docker-compose-multiple-networks.yml
+++ b/docker-compose-multiple-networks.yml
@@ -9,6 +9,8 @@ services:
     ports:
       - "${IP:-0.0.0.0}:80:80"
       - "${IP:-0.0.0.0}:443:443"
+      - "${IPv6:-::/0}:80:80"
+      - "${IPv6:-::/0}:443:443"
     volumes:
       - ${NGINX_FILES_PATH:-./data}/conf.d:/etc/nginx/conf.d
       - ${NGINX_FILES_PATH:-./data}/vhost.d:/etc/nginx/vhost.d
@@ -36,6 +38,8 @@ services:
       - ${NGINX_FILES_PATH:-./data}/htpasswd:/etc/nginx/htpasswd:ro
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro
+    environment:
+      ENABLE_IPV6: "true"
     networks:
       - default
       - outside

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     ports:
       - "${IP:-0.0.0.0}:80:80"
       - "${IP:-0.0.0.0}:443:443"
+      - "${IPv6:-::/0}:80:80"
+      - "${IPv6:-::/0}:443:443"
     volumes:
       - ${NGINX_FILES_PATH:-./data}/conf.d:/etc/nginx/conf.d
       - ${NGINX_FILES_PATH:-./data}/vhost.d:/etc/nginx/vhost.d
@@ -33,6 +35,8 @@ services:
       - ${NGINX_FILES_PATH:-./data}/htpasswd:/etc/nginx/htpasswd:ro
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro
+    environment:
+      ENABLE_IPV6: "true"
     logging:
       options:
         max-size: ${NGINX_GEN_LOG_MAX_SIZE:-2m}

--- a/start.sh
+++ b/start.sh
@@ -14,7 +14,8 @@ else
 fi
 
 # 2. Create docker network
-docker network create $NETWORK
+docker run -d --restart=always -v /var/run/docker.sock:/var/run/docker.sock:ro --privileged --net=host robbertkl/ipv6nat
+docker network create --ipv6 --subnet=fd00:dead:beef::/48 $NETWORK
 
 # 3. Verify if second network is configured
 if [ ! -z ${SERVICE_NETWORK+X} ]; then


### PR DESCRIPTION
Add IPv6 NAT functionality

- Add IPv6 variable in .env.sample to map external IPv6 address
- Map IPv6 port forwarding in Docker compose files
- Add ENABLE_IPV6 to compose files to enable IPv6 routing from host
- Add ipv6nat in start.sh to enable IPv6 NAT between containers
- Update docker network create in start.sh to assign IPv6 addresses to all containers
- Resolves issue [IPv6 Configuration](https://github.com/evertramos/docker-compose-letsencrypt-nginx-proxy-companion/issues/45#issuecomment-424880799)