### PR TITLE
Support for running on Synology DSM Nas and configureable ports for docker host

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,6 +19,16 @@ LETS_ENCRYPT=nginx-letsencrypt
 IP=0.0.0.0
 
 #
+# Set the local exposed ports for http and https - this  will allow you to run with a legacy web 
+# server already installed for local use
+#
+# NOTE: For this to function your internet router must forward the official ports to the mapped ports - 
+#       in this example external port 80 to docker host 81 and external port 443 to docker host 444
+#
+#DOCKER_HTTP=81
+#DOCKER_HTTPS=444
+
+#
 # Default Network
 #
 NETWORK=webproxy

--- a/.env.sample
+++ b/.env.sample
@@ -19,16 +19,6 @@ LETS_ENCRYPT=nginx-letsencrypt
 IP=0.0.0.0
 
 #
-# Set the local exposed ports for http and https - this  will allow you to run with a legacy web 
-# server already installed for local use
-#
-# NOTE: For this to function your internet router must forward the official ports to the mapped ports - 
-#       in this example external port 80 to docker host 81 and external port 443 to docker host 444
-#
-#DOCKER_HTTP=81
-#DOCKER_HTTPS=444
-
-#
 # Default Network
 #
 NETWORK=webproxy
@@ -95,3 +85,11 @@ NGINX_FILES_PATH=./nginx-data
 #NGINX_LETSENCRYPT_LOG_DRIVER=json-file
 #NGINX_LETSENCRYPT_LOG_MAX_SIZE=2m
 #NGINX_LETSENCRYPT_LOG_MAX_FILE=10
+
+#
+# Set the local exposed ports for http and https on the Host
+#
+# NOTE: The default values are 80 and 443, only change this options if you really know what you are doing
+#
+#DOCKER_HTTP=80
+#DOCKER_HTTPS=443

--- a/Docs/HOWTO-Synlogy.md
+++ b/Docs/HOWTO-Synlogy.md
@@ -1,0 +1,27 @@
+## Port mapping
+Synology default installs a web server on port 80 blocking certificate generation. 
+
+To circumvent this - if you do not need extenral access to the default web server (and you should not expose it anyway) configure your .env to use alternative ports and your router to forward the external official port to the alternative internal ports:
+
+#
+# Set the local exposed ports for http and https - this  will allow you to run with a legacy web 
+# server already installed for local use
+#
+# NOTE: For this to function your internet router must forward the official ports to the mapped ports - 
+#       in this example external port 80 to docker host 81 and external port 443 to docker host 444
+#
+DOCKER_HTTP=81
+DOCKER_HTTPS=444
+
+## File permissions
+To setup the needed configuration directoties and proper permissions run the below commands (assuming default ./data is where you have your catalog for persistent files)
+
+mkdir -p data/certs
+mkdir data/htpasswd
+mkdir data/conf.d
+mkdir data/vhost.d
+mkdir data/html
+chgrp -R 101 data
+chmod -R g+rwx data
+
+Contributed by https://github.com/nicolailang/

--- a/Docs/HOWTO-Synlogy.md
+++ b/Docs/HOWTO-Synlogy.md
@@ -4,7 +4,7 @@ Synology default installs a web server on port 80 blocking certificate generatio
 To circumvent this - if you do not need external access to the default web server (and you should not expose it anyway) configure your .env to use alternative ports and your router to forward the external official port to the alternative internal ports:
 
 #
-# Set the local exposed ports for http and https - this  will allow you to run with a legacy web 
+# Set the local exposed ports for http and https - this will allow you to run with a legacy web 
 # server already installed for local use
 #
 # NOTE: For this to function your internet router must forward the official ports to the mapped ports - 

--- a/Docs/HOWTO-Synlogy.md
+++ b/Docs/HOWTO-Synlogy.md
@@ -1,7 +1,7 @@
 ## Port mapping
 Synology default installs a web server on port 80 blocking certificate generation. 
 
-To circumvent this - if you do not need extenral access to the default web server (and you should not expose it anyway) configure your .env to use alternative ports and your router to forward the external official port to the alternative internal ports:
+To circumvent this - if you do not need external access to the default web server (and you should not expose it anyway) configure your .env to use alternative ports and your router to forward the external official port to the alternative internal ports:
 
 #
 # Set the local exposed ports for http and https - this  will allow you to run with a legacy web 

--- a/docker-compose-multiple-networks.yml
+++ b/docker-compose-multiple-networks.yml
@@ -7,9 +7,9 @@ services:
     container_name: ${NGINX_WEB:-nginx-web}
     restart: always
     ports:
-      - "${IP:-0.0.0.0}:80:80"
-      - "${IP:-0.0.0.0}:443:443"
-    volumes:
+      - "${IP:-0.0.0.0}:${DOCKER_HTTP:-80}:80"
+      - "${IP:-0.0.0.0}:${DOCKER_HTTPS:-443}:443"
+     volumes:
       - ${NGINX_FILES_PATH:-./data}/conf.d:/etc/nginx/conf.d
       - ${NGINX_FILES_PATH:-./data}/vhost.d:/etc/nginx/vhost.d
       - ${NGINX_FILES_PATH:-./data}/html:/usr/share/nginx/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     container_name: ${NGINX_WEB:-nginx-web}
     restart: always
     ports:
-      - "${IP:-0.0.0.0}:80:80"
-      - "${IP:-0.0.0.0}:443:443"
+      - "${IP:-0.0.0.0}:${DOCKER_HTTP:-80}:80"
+      - "${IP:-0.0.0.0}:${DOCKER_HTTPS:-443}:443"
     volumes:
       - ${NGINX_FILES_PATH:-./data}/conf.d:/etc/nginx/conf.d
       - ${NGINX_FILES_PATH:-./data}/vhost.d:/etc/nginx/vhost.d


### PR DESCRIPTION
This PR adds functionality to specify alternative ports in .env and includes a HOWTO for running the stack on a Synology NAS. 