### PR TITLE
Improve start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -72,5 +72,3 @@ else
 fi
 
 exit 0
-
-exit 0

--- a/start.sh
+++ b/start.sh
@@ -61,8 +61,16 @@ fi
 # Check if you have multiple network
 if [ -z ${SERVICE_NETWORK+X} ]; then
     docker-compose up -d
+    sleep 1
+    docker-compose start
+    docker-compose ps
 else
     docker-compose -f docker-compose-multiple-networks.yml up -d
+    sleep 1
+    docker-compose start
+    docker-compose ps
 fi
+
+exit 0
 
 exit 0


### PR DESCRIPTION
Hi, 9 out of 10 times I start with this script `nginx-gen` does not start and each time I have to start it manually which is a pain.
making it pause for 1 second and doing `docker-compose start` makes sure it started 100% of the time. And it does skip the ones already started.
Also adding `docker-compose ps` at the end is a nice way to confirm it is up and running as it should.

Please accept this.

Cheers,

Khalil