### PR TITLE
Fix NETWORK_ACCESS environment variable taken from nginx-proxy

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -260,7 +260,11 @@ server {
 
 	{{ if eq $network_tag "internal" }}
 	# Only allow traffic from internal clients
-	include /etc/nginx/network_internal.conf;
+	allow 127.0.0.0/8;
+	allow 10.0.0.0/8;
+	allow 192.168.0.0/16;
+	allow 172.16.0.0/12;
+	deny all;
 	{{ end }}
 
 	{{ template "ssl_policy" (dict "ssl_policy" $ssl_policy) }}
@@ -330,7 +334,11 @@ server {
 
 	{{ if eq $network_tag "internal" }}
 	# Only allow traffic from internal clients
-	include /etc/nginx/network_internal.conf;
+	allow 127.0.0.0/8;
+	allow 10.0.0.0/8;
+	allow 192.168.0.0/16;
+	allow 172.16.0.0/12;
+	deny all;
 	{{ end }}
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}


### PR DESCRIPTION
I've taken [this conf file](https://github.com/jwilder/nginx-proxy/blob/master/network_internal.conf) and put it straight into the relevant bits in `nginx.tmpl`. [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy) includes this in their docker image, but as there's no custom one here I guess it was forgotten about.

If anyone is curious, setting the environment variable `NETWORK_ACCESS` to "internal" on a container restricts it's access to private networks and the local machine.